### PR TITLE
Fix syntax error in README configure block example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ or set multiple options with a block:
 
 ```ruby
 ReadabilityParser.configure do |readability|
-  readability.api_token = READABILITY_API_TOKEN,
+  readability.api_token = READABILITY_API_TOKEN
   readability.format = :json
 end
 ```


### PR DESCRIPTION
Fixes small syntax error for the configure block example given in the README
